### PR TITLE
[BUG FIX] fixes issue where previous fragments were being removed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,8 @@ class CombinedQueryBuilderImpl<TData = any, TVariables = OperationVariables> imp
       variableDefinitions: opDefs.flatMap(def => def.variableDefinitions || [])
     }]
     const encounteredFragmentList = new Set<string>()
-    for (const definition of document.definitions) {
+    const combinedDocumentDefinitions = this.document.definitions.concat(document.definitions)
+    for (const definition of combinedDocumentDefinitions) {
       if (definition.kind === 'OperationDefinition') {
         continue
       }


### PR DESCRIPTION
In my previous PR https://github.com/domasx2/graphql-combine-query/pull/3, I fixed one issue but unfortunately created another. I mistakenly removed the concatenation line and was only iterating over new fragments. This meant that multiple queries with different types of fragments were removed. I've fixed the issue and added another test for it. Really sorry about that 😅