### PR TITLE
fixed bug of ignoring renaming functions of addN method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,8 +133,8 @@ export default function combinedQuery(operationName: string): NewCombinedQueryBu
     add<TData = any, TVariables extends OperationVariables={}>(document: DocumentNode, variables?: TVariables ) {
       return new CombinedQueryBuilderImpl<TData, TVariables>(this.operationName, document, variables)
     },
-    addN<TVariables = OperationVariables>(document: DocumentNode, variables: TVariables[]): CombinedQueryBuilder<{}, {}> {
-      return new CombinedQueryBuilderImpl<{}, {}>(this.operationName,  emptyDoc).addN<TVariables>(document, variables)
+    addN<TVariables = OperationVariables>(document: DocumentNode, variables: TVariables[], variableRenameFn?: RenameFnWithIndex, fieldRenameFn?: RenameFnWithIndex): CombinedQueryBuilder<{}, {}> {
+      return new CombinedQueryBuilderImpl<{}, {}>(this.operationName,  emptyDoc).addN<TVariables>(document, variables, variableRenameFn, fieldRenameFn)
     }
   }
 }


### PR DESCRIPTION
There was a problem of ignoring renaming functions when addN method had been invoked as the first method in the chain